### PR TITLE
Fix deprecated GitHub Actions

### DIFF
--- a/.github/workflows/esp32-ci.yml
+++ b/.github/workflows/esp32-ci.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.9'
 
     - name: Cache ESP-IDF
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.espressif
         key: ${{ runner.os }}-espidf-${{ hashFiles('**/sdkconfig') }}
@@ -62,7 +62,7 @@ jobs:
         echo "Build artifacts verified successfully"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: esp32-firmware
         path: |

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.9'
 
     - name: Cache ESP-IDF
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.espressif
         key: ${{ runner.os }}-espidf-${{ hashFiles('**/sdkconfig') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: '3.9'
 
     - name: Cache ESP-IDF
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.espressif
         key: ${{ runner.os }}-espidf-${{ hashFiles('**/sdkconfig') }}
@@ -97,22 +97,12 @@ jobs:
         echo "- AquaForte Vario+ II inverter (optional)" >> release-notes.md
 
     - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ github.ref }}
-        release_name: ESP32 Pool Pump Controller ${{ github.ref }}
+        name: ESP32 Pool Pump Controller ${{ github.ref }}
         body_path: release-notes.md
         draft: false
         prerelease: false
-
-    - name: Upload release assets
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: esp32-pool-pump-controller-${{ github.ref }}.tar.gz
-        asset_name: esp32-pool-pump-controller-${{ github.ref }}.tar.gz
-        asset_content_type: application/gzip
+        files: |
+          esp32-pool-pump-controller-${{ github.ref }}.tar.gz

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.9'
 
     - name: Cache ESP-IDF
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.espressif
         key: ${{ runner.os }}-espidf-${{ hashFiles('**/sdkconfig') }}
@@ -84,7 +84,7 @@ jobs:
         echo "Total test files: $(find test -name "test_*.c" | wc -l)" >> test-report.md
 
     - name: Upload test report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-report
         path: test-report.md


### PR DESCRIPTION
- Update actions/upload-artifact from v3 to v4
- Update actions/cache from v3 to v4
- Replace deprecated actions/create-release@v1 and actions/upload-release-asset@v1 with softprops/action-gh-release@v1
- All workflows now use current, supported action versions